### PR TITLE
guard against use with unicode tex

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -24,12 +24,12 @@ do only supply macros, which generate aesthetic glyphs, no hacks.
 Information about this package, including a link to its source code
 repository, can be found at
 
-    <http://wolfgang.jeltsch.info/software/tex/ucs>  .
+    <https://github.com/LaTeX-Package-Repositories/ucs>more 
 
 =========
 
 (C) 2000       by Dominique Unruh  <unruh@ut.ee>
 (C) 2011--2013 by Wolfgang Jeltsch <wolfgang@cs.ioc.ee>
-(C) 2022       David Carlisle david.carlisle@latex-project.org
+(C) 2022--2023    David Carlisle david.carlisle@latex-project.org
 
 See the LICENSE file for licensing informations.

--- a/build.lua
+++ b/build.lua
@@ -1,6 +1,6 @@
 
 module = "ucs"
-checkengines={"pdftex"}
+checkengines={"pdftex","luatex"}
 checkruns=2
 
 installfiles = {"*.def","*.sty"}

--- a/testfiles/hyperref-1.luatex.tlg
+++ b/testfiles/hyperref-1.luatex.tlg
@@ -1,8 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-(../uni-0.def
-File: uni-0.def ....-..-.. UCS: Unicode data U+0000..U+00FF
-) [1
+[1
 ] (hyperref-1.aux)
 Package rerunfilecheck Info: File `hyperref-1.out' has not changed.
 (rerunfilecheck)             Checksum: 39CC442D7ED2E76135AD47928070D56F;74.

--- a/testfiles/sx-1.luatex.tlg
+++ b/testfiles/sx-1.luatex.tlg
@@ -1,0 +1,12 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+(../inputenc.sty
+Package: inputenc ....-..-.. v... Input encoding file
+\inpenc@prehook=\toks...
+\inpenc@posthook=\toks...
+Package inputenc Warning: inputenc package ignored with utf8 based engines.
+)
+[1
+] (sx-1.aux)
+Package rerunfilecheck Info: File `sx-1.out' has not changed.
+(rerunfilecheck)             Checksum: 593EEFC22A6D155F9B4975AF9C58C3BF;261.

--- a/testfiles/uppercase-1.luatex.tlg
+++ b/testfiles/uppercase-1.luatex.tlg
@@ -1,0 +1,3 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+LaTeX Font Info:    Trying to load font information for LGR+lmr on input line ....

--- a/testfiles/uppercase-1.tlg
+++ b/testfiles/uppercase-1.tlg
@@ -2,7 +2,6 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 (../uni-0.def
 File: uni-0.def ....-..-.. UCS: Unicode data U+0000..U+00FF
-)
-(../uni-3.def
+) (../uni-3.def
 File: uni-3.def ....-..-.. UCS: Unicode data U+0300..U+03FF
 )

--- a/ucs.dtx
+++ b/ucs.dtx
@@ -2,7 +2,7 @@
 % -*-coding: utf-8; mode: latex;-*-
 %
 %<*driver>
-\ProvidesFile{ucs.dtx}[2022/08/07 v2.3
+\ProvidesFile{ucs.dtx}[2023/11/09 v2.4
    UCS: Master document for generating documentation for ucs.sty]
 %
 \documentclass{ltxdoc}
@@ -149,10 +149,10 @@
 % low level \TeX\ errors.
 %
 % The original maintainers kindly allowed the \LaTeX\ project members
-% to make this |2022/08/07 v2.3| release.
+% to make the releases from |2023/11/09 v2.3|.       .
 %
 % The remaining documentation is unchanged but version 2.3 introduces
-% the following changes
+% the following changes, and version 2.4 aborts with a warning if used with Uniocde TeX.
 %
 % \begin{itemize}
 % \item If a document uses |\usepackage[utf8x]{inputenc}| when the
@@ -493,13 +493,26 @@
 % \xsection{File \texttt{ucs.sty}}
 %    \begin{macrocode}
 %<*ucs.sty>
+%    \end{macrocode}
+%    \begin{macrocode}
+\ifx\ProvidesPackage\undefined\else
+\ProvidesPackage{ucs}[2023/11/09 v2.4 UCS: Unicode input support]%
+\fi
+\ifx\Umathchar\undefined\else
+\ifx\PackageWarningNoLine\undefined\else
+\PackageWarningNoLine{ucs}{ucs package ignored with utf8 based engines}
+\fi
+\expandafter\endinput
+\fi
+%    \end{macrocode}
+%    \begin{macrocode}
 % ^^A FIXME: What is the following code for? Is it for people who want to use ucs.sty with Plain TeX
 % ^^A        or ConTeXt?
 \catcode`\@11
 
 \ifx\AddToHook\@undefined\else
 \AddToHook{package/hyperref/after}{%
- \def\HyPsd@expand@utfvii{%
+ \def\HyPsd@expand@UTFviii{%
     \count@"C2
     \@tempcnta"E0
     \def\UTFviii@tmp{%
@@ -520,6 +533,7 @@
     \UTFviii@loop
 
   }
+ \let\HyPsd@expand@utfvii\HyPsd@expand@UTFviii
 }
 \fi
 
@@ -721,11 +735,6 @@
 %    \end{macrocode}
 % \end{macro}
 %
-%    \begin{macrocode}
-\ifx\ProvidesPackage\undefined\else
-\ProvidesPackage{ucs}[2022/08/07 v2.3 UCS: Unicode input support]%
-\fi
-%    \end{macrocode}
 % ^^A FIXME: We should update the date of ucs.sty even if the file ucs.sty has not changed, but the
 % ^^A        character mappings have. Otherwise, we cannot specify a complience level by adding a
 % ^^A        date to \usepackage{ucs} or \RequirePackage{ucs}.
@@ -2127,7 +2136,7 @@
 %    \begin{macrocode}
 %<*utf8x.def>
 \ifx\ProvidesFile\undefined\else
-\ProvidesFile{utf8x.def}[2022/08/07 UCS: Input encoding UTF-8]%
+\ProvidesFile{utf8x.def}[2023/11/09 UCS: Input encoding UTF-8]%
 
 \ifx\uc@char@notloaded\@undefined
 

--- a/ucs.dtx
+++ b/ucs.dtx
@@ -149,10 +149,10 @@
 % low level \TeX\ errors.
 %
 % The original maintainers kindly allowed the \LaTeX\ project members
-% to make the releases from |2023/11/09 v2.3|.       .
+% to make the releases from |2022/08/07 v2.3|.       .
 %
 % The remaining documentation is unchanged but version 2.3 introduces
-% the following changes, and version 2.4 aborts with a warning if used with Uniocde TeX.
+% the following changes, and version 2.4 aborts with a warning if used with Unicode TeX.
 %
 % \begin{itemize}
 % \item If a document uses |\usepackage[utf8x]{inputenc}| when the


### PR DESCRIPTION
Make ucs.sty just warn and do nothing with unicode.tex (as already done with utf8x.def)

Also define 

` \let\HyPsd@expand@utfvii\HyPsd@expand@UTFviii`

for expected fix to the name in hyperref