### PR TITLE
Replaced email addresses of Dominique Unruh by a new address.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2000      by Dominique Unruh  <unruh@ut.ee>
+Copyright 2000      by Dominique Unruh  <latex.ucs.0vm69c@x.unruh.de>
 Copyright 2011-2013 by Wolfgang Jeltsch <wolfgang@cs.ioc.ee>
 Copyright 2022-2024 by David Carlisle   <david.carlisle@latex-project.org>
 

--- a/README.txt
+++ b/README.txt
@@ -28,7 +28,7 @@ repository, can be found at
 
 =========
 
-(C) 2000       by Dominique Unruh  <unruh@ut.ee>
+(C) 2000       by Dominique Unruh  <latex.ucs.0vm69c@x.unruh.de>
 (C) 2011--2013 by Wolfgang Jeltsch <wolfgang@cs.ioc.ee>
 (C) 2022--2024    David Carlisle david.carlisle@latex-project.org
 

--- a/latexout.pl
+++ b/latexout.pl
@@ -20,7 +20,7 @@ not displayed.
 
 =head1 AUTHOR
 
-Dominique Unruh <I<unruh@ut.ee>>.
+Dominique Unruh <I<latex.ucs.0vm69c@x.unruh.de>>.
 
 =head1 SEE ALSO
 

--- a/makeunidef.pl
+++ b/makeunidef.pl
@@ -185,7 +185,7 @@ containing the words B<bug report: makeunidef.pl> in the subject.
 
 =head1 AUTHOR
 
-Dominique Unruh <I<unruh@ut.ee>>.
+Dominique Unruh <I<latex.ucs.0vm69c@x.unruh.de>>.
 
 =head1 MAINTAINER
 

--- a/ucs.ins
+++ b/ucs.ins
@@ -3,7 +3,7 @@
 
 \preamble
 
-Copyright 2001 Dominique Unruh  <unruh@ut.ee>
+Copyright 2001 Dominique Unruh  <latex.ucs.0vm69c@x.unruh.de>
 Copyright 2013 Wolfgang Jeltsch <wolfgang@cs.ioc.ee>
 Copyright 2022 David Carlisle https://github.com/LaTeX-Package-Repositories/ucs
 


### PR DESCRIPTION
Replacing several mentions of my email address by a different one (to reduce the risk that the original address is used in spam).